### PR TITLE
[FEAT] 카카오 로그인 링크 연결

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+VITE_KAKAO_CLIENT_ID=9555ae675b3e27488bd10e7f09ea12bd
+VITE_KAKAO_REDIRECT_URI=http://localhost:8080/login/oauth2/code/kakao
+

--- a/src/pages/SignUp/SignUp3.tsx
+++ b/src/pages/SignUp/SignUp3.tsx
@@ -3,8 +3,18 @@ import { useNavigate } from "react-router-dom";
 import KakaoIcon from "../../assets/kakao.svg";
 import AppleIcon from '../../assets/apple.svg'
 
+const CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
+
 const SignUp3: React.FC = () => {
   const navigate = useNavigate();
+
+  const handleKakaoLogin = () => {
+    // Kakao 로그인 URL 생성
+    const kakaoLoginUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}`;
+    // 해당 URL로 리다이렉트
+    window.location.href = kakaoLoginUrl;
+  };
 
   const handleNavigation = (navigateTo: string) => {
     navigate(`/${navigateTo}`);
@@ -39,7 +49,7 @@ const SignUp3: React.FC = () => {
       style={{
         border: "1px solid #FFEB01",
       }}
-      onClick={() => handleNavigation("kakao")}
+      onClick={handleKakaoLogin}
     >
       <img
         src={KakaoIcon}

--- a/src/pages/Start/Start.tsx
+++ b/src/pages/Start/Start.tsx
@@ -4,8 +4,18 @@ import KakaoIcon from '../../assets/kakao.svg'
 import AppleIcon from '../../assets/apple.svg'
 import BigWhiteButton from '../../components/BigWhiteButton'
 
+const CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
+
 const Start = () => {
   const navigate = useNavigate()
+
+  const handleKakaoLogin = () => {
+    // Kakao 로그인 URL 생성
+    const kakaoLoginUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}`;
+    // 해당 URL로 리다이렉트
+    window.location.href = kakaoLoginUrl;
+  };
 
   return (
     <div className="flex items-center justify-center h-screen">
@@ -26,7 +36,7 @@ const Start = () => {
             style={{
               border: '1px solid #FFEB01',
             }}
-            onClick={() => navigate('kakao')}
+            onClick={handleKakaoLogin}
           >
             <img src={KakaoIcon} alt="Kakao Icon" className="w-5 h-5" />
             카카오로 계속하기


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #73 

## 📝 작업 내용
> 카카오 로그인 링크 연결(시작페이지와 회원가입 signup3 페이지)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/def77a01-df4f-4704-95ae-783c47e2a9ff)


## 💬 리뷰 요구사항(선택)
> 
