### PR TITLE
Feature/questions

### DIFF
--- a/src/components/BigGrayButton.tsx
+++ b/src/components/BigGrayButton.tsx
@@ -6,6 +6,7 @@ interface QuestionButtonComponentProps {
   navigateTF?: boolean
   onClick?: any
   disabled?: boolean
+  isPink?: boolean
 }
 
 const BigGrayButton: React.FC<QuestionButtonComponentProps> = ({
@@ -14,6 +15,7 @@ const BigGrayButton: React.FC<QuestionButtonComponentProps> = ({
   navigateTF = true,
   disabled = false,
   onClick,
+  isPink = false,
 }) => {
   const navigate = useNavigate()
 
@@ -22,16 +24,17 @@ const BigGrayButton: React.FC<QuestionButtonComponentProps> = ({
     if (navigateTF) navigate(`/${navigateTo}`)
   }
 
+  const colorClasses = isPink ? 'hover:bg-[#F2E1DA] active:bg-[#CEB6AD]' : 'hover:bg-[#DAE6CB] active:bg-[#ACB99C]'
+
   return disabled === false ? (
     <button
-      className="
+      className={`
         w-[327px] h-[58px] text-[16px] font-[Pretendard] font-semibold 
         text-[#191919] text-center rounded-[15px] bg-[#D1D1D1] 
         shadow-[0px_2px_5px_-2px_rgba(0,0,0,0.25)] filter-none mb-3 
-        transition-colors 
-        hover:bg-[#DAE6CB] 
-        active:bg-[#ACB99C]
-      "
+        transition-colors
+        ${colorClasses}
+      `}
       style={{ boxShadow: `0px 2px 5px -2px rgba(0, 0, 0, 0.25)` }}
       onClick={handleClick}
     >

--- a/src/components/BigGrayButton.tsx
+++ b/src/components/BigGrayButton.tsx
@@ -24,7 +24,14 @@ const BigGrayButton: React.FC<QuestionButtonComponentProps> = ({
 
   return disabled === false ? (
     <button
-      className="w-[327px] h-[58px] text-[16px] font-[Pretendard] font-semibold text-[#191919] text-center rounded-[15px] bg-[#D1D1D1] shadow-[0px_2px_5px_-2px_rgba(0,0,0,0.25)] filter-none mb-3 transition-colors hover:bg-[#DAE6CB]"
+      className="
+        w-[327px] h-[58px] text-[16px] font-[Pretendard] font-semibold 
+        text-[#191919] text-center rounded-[15px] bg-[#D1D1D1] 
+        shadow-[0px_2px_5px_-2px_rgba(0,0,0,0.25)] filter-none mb-3 
+        transition-colors 
+        hover:bg-[#DAE6CB] 
+        active:bg-[#ACB99C]
+      "
       style={{ boxShadow: `0px 2px 5px -2px rgba(0, 0, 0, 0.25)` }}
       onClick={handleClick}
     >
@@ -32,7 +39,12 @@ const BigGrayButton: React.FC<QuestionButtonComponentProps> = ({
     </button>
   ) : (
     <button
-      className="w-[327px] h-[58px] text-[16px] font-[Pretendard] font-semibold text-[#191919] text-center rounded-[15px] bg-[#D1D1D1] shadow-[0px_2px_5px_-2px_rgba(0,0,0,0.25)] filter-none mb-3 transition-colors"
+      className="
+        w-[327px] h-[58px] text-[16px] font-[Pretendard] font-semibold 
+        text-[#191919] text-center rounded-[15px] bg-[#D1D1D1] 
+        shadow-[0px_2px_5px_-2px_rgba(0,0,0,0.25)] filter-none mb-3 
+        transition-colors
+      "
       style={{ boxShadow: `0px 2px 5px -2px rgba(0, 0, 0, 0.25)` }}
     >
       {text}

--- a/src/pages/Record/ReviewWrite.tsx
+++ b/src/pages/Record/ReviewWrite.tsx
@@ -39,7 +39,7 @@ const ReviewWrite = () => {
         className="h-[413px] bg-white rounded-[15px] shadow-whiteBox text-top ps-[22px] pt-[30px] text-[14px] mb-[16px]"
         placeholder="다른 사용자를 위해 의견을 적어주세요 (선택)"
       ></textarea>
-      <BigGrayButton text="후기 등록하기" navigateTo="home" onClick={() => postReview()} />
+      <BigGrayButton text="후기 등록하기" navigateTo="home" isPink={true} onClick={() => postReview()} />
     </div>
   )
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #26 

## 📝 작업 내용
> figma 디자인에서 다음 버튼(질문페이지의 BigGrayButton)이 hover과 press(css에서는 action)별로 색깔이 따로 있어서 해당 부분 구현했습니다.
> 질문 페이지 외의 비슷한 버튼(비슷한 크기/기능, 회색이나 hover/action 때 색깔이 변함) 들이 여러개 있던데, 코드를 확인해보니 각자 개별 코드로 구현해놓으신 경우가 대부분이어서 수정하지 않았습니다.
그러나 ReviewWrite.tsx 에서만  BigGrayButton 이 import되어 있어, 해당 부분에서 사용할 수 있게끔 isPink 속성을 추가했습니다. 해당 페이지의 버튼은 눌렸을 때 분홍색 계열의 색으로 변합니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
