### PR TITLE
[Design] 단탄지 초과된 경우에 UI 안깨지게

### DIFF
--- a/src/components/main/CalorieCard.tsx
+++ b/src/components/main/CalorieCard.tsx
@@ -37,11 +37,11 @@ const CalorieCard: React.FC<CalorieCardProps> = ({
     return <SkeletonCalorieCard />;
   }
 
-  // API 데이터가 없을 경우 기본값 처리
-  const calorieProgress = ((apiData.curCalories ?? 0) / (apiData.calories ?? 1)) * 100;
-  const carbProgress = ((apiData.curCarbos ?? 0) / (apiData.carbos ?? 1)) * 100;
-  const proteinProgress = ((apiData.curProteins ?? 0) / (apiData.proteins ?? 1)) * 100;
-  const fatProgress = ((apiData.curFats ?? 0) / (apiData.fats ?? 1)) * 100;
+  // 초과된 경우에도 최대 100%로 제한
+  const calorieProgress = Math.min(100, ((apiData.curCalories ?? 0) / (apiData.calories ?? 1)) * 100);
+  const carbProgress = Math.min(100, ((apiData.curCarbos ?? 0) / (apiData.carbos ?? 1)) * 100);
+  const proteinProgress = Math.min(100, ((apiData.curProteins ?? 0) / (apiData.proteins ?? 1)) * 100);
+  const fatProgress = Math.min(100, ((apiData.curFats ?? 0) / (apiData.fats ?? 1)) * 100);
 
   return (
     <div


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
> 단탄지 값이 초과되면 UI가 깨지는 오류 수정했습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4d433a53-c3bd-47ac-a4bd-3c89347a60ca)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
